### PR TITLE
Corrige a propriedade "defaultJSExtensions"

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -43,7 +43,7 @@
     <script src="lib/jquery.min.js"></script>
     <script src="lib/system.js"></script>
     <script>
-        System.defaultJSExtension = true;
+        System.defaultJSExtensions = true;
         System.import("js/app.js").catch(exception => console.error(exception));
     </script>
 


### PR DESCRIPTION
A propriedade "defaultJSExtensions" estava sendo usada sem o "s" ao final, o que impossibilitava do loader achar as dependências sem usar a extensão dos arquivos JS. 

Erro identificado a partir de um post no curso Alura. A partir dessa modificação é possível tirar as extensões dos arquivos nos "import"s